### PR TITLE
chore: update action runtime to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,5 +37,5 @@ outputs:
     description: 'The created Git tag (if enabled)'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
Update `runs.using` in `action.yml` from `node16` to `node20`.

## Motivation
- Node16 is deprecated on GitHub Actions.
- GitHub officially supports `node20` for JavaScript actions.
  Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax?utm_source=chatgpt.com#runs-for-javascript-actions

## Impact
- No breaking change expected.
- Action will continue to run on supported Node.js runtime.
